### PR TITLE
Feat/11 specify sheets to fetch

### DIFF
--- a/packages/lokse/README.md
+++ b/packages/lokse/README.md
@@ -97,6 +97,7 @@ So just create `lokse.config.js`, `.lokserc`, `.lokserc.yml`, `.lokserc.json` or
 * **`languages`** - list of languages you want to generate translations for. Also names of columns in spreadsheet
 * **`column`** - name of spreadsheet columm containing translation ids
 * **`format`** - format of output translation file
+* **`sheets`** - titles of sheets to use. Can be string or array of string. If none provided, all sheets are used.
 
 Example of `.lokserc`
 
@@ -110,7 +111,8 @@ Example of `.lokserc`
     "fr"
   ],
   "column": "key_web",
-  "format": "json"
+  "format": "json",
+  "sheets": ["App translations", "Legal docs"]
 }
 ```
 
@@ -172,6 +174,8 @@ OPTIONS
 
   -l, --languages=languages        translation columns languages. Multiple values are comma separated. For example
                                    cs,en,fr
+
+  -s, --sheets=sheets              sheets to get translations from. Name or list of names, comma sepaarated. For example
 
 EXAMPLES
   $ lokse update

--- a/packages/lokse/package.json
+++ b/packages/lokse/package.json
@@ -61,7 +61,6 @@
   "scripts": {
     "build": "tsc -b",
     "postpack": "rm -f oclif.manifest.json",
-    "posttest": "yarn lint",
     "prepack": "rm -rf lib && yarn build && oclif-dev manifest && oclif-dev readme",
     "test": "jest",
     "version": "yarn readme && yarn changelog && code --wait CHANGELOG.md && git add README.md CHANGELOG.md",

--- a/packages/lokse/src/commands/update.ts
+++ b/packages/lokse/src/commands/update.ts
@@ -47,7 +47,7 @@ class Update extends Base {
       char: "s",
       name: "sheets",
       description:
-        "sheets to get translations from. Name or list of names, comma sepaarated. For example ",
+        "sheets to get translations from. Name or list of names, comma separated. For example Translations1,Translations2",
     }),
   };
 

--- a/packages/lokse/src/commands/update.ts
+++ b/packages/lokse/src/commands/update.ts
@@ -43,6 +43,12 @@ class Update extends Base {
       options: outputFormats,
       description: `output format. Default is ${defaultFormat}.`,
     }),
+    sheets: flags.string({
+      char: "s",
+      name: "sheets",
+      description:
+        "sheets to get translations from. Name or list of names, comma sepaarated. For example ",
+    }),
   };
 
   async run() {
@@ -53,6 +59,7 @@ class Update extends Base {
     const languages = flags.languages?.split(",") ?? this.conf?.languages;
     const column = flags.col ?? this.conf?.column;
     const format = flags.format ?? this.conf?.format ?? defaultFormat;
+    const sheets = flags.sheets?.split(",") ?? undefined;
 
     cliFlags.id.invariant(sheetId);
 
@@ -72,7 +79,7 @@ class Update extends Base {
 
     const outputTransformer = transformersByFormat[format];
 
-    const reader = new Reader(sheetId, "*");
+    const reader = new Reader(sheetId, sheets);
     const writer = new FileWriter();
 
     for (const language of languages) {

--- a/packages/lokse/src/commands/update.ts
+++ b/packages/lokse/src/commands/update.ts
@@ -59,7 +59,7 @@ class Update extends Base {
     const languages = flags.languages?.split(",") ?? this.conf?.languages;
     const column = flags.col ?? this.conf?.column;
     const format = flags.format ?? this.conf?.format ?? defaultFormat;
-    const sheets = flags.sheets?.split(",") ?? this.conf?.sheets ?? undefined;
+    const sheets = flags.sheets?.split(",") ?? this.conf?.sheets;
 
     cliFlags.id.invariant(sheetId);
 

--- a/packages/lokse/src/commands/update.ts
+++ b/packages/lokse/src/commands/update.ts
@@ -5,7 +5,7 @@ import * as ora from "ora";
 import { NAME } from "../constants";
 import Base from "../base";
 import { OutputFormat } from "../constants";
-import Reader from "../core/reader";
+import Reader, { WorksheetReader } from "../core/reader";
 import { transformersByFormat } from "../core/transformer";
 import { FileWriter } from "../core/writer";
 import * as cliFlags from "../flags";
@@ -59,7 +59,7 @@ class Update extends Base {
     const languages = flags.languages?.split(",") ?? this.conf?.languages;
     const column = flags.col ?? this.conf?.column;
     const format = flags.format ?? this.conf?.format ?? defaultFormat;
-    const sheets = flags.sheets?.split(",") ?? undefined;
+    const sheets = flags.sheets?.split(",") ?? this.conf?.sheets ?? undefined;
 
     cliFlags.id.invariant(sheetId);
 
@@ -74,6 +74,12 @@ class Update extends Base {
     if (!Array.isArray(languages)) {
       throw new IncorrectFlagValue(
         `🤷‍♂️ Translation columns have to be list of languages, but ${languages} given`
+      );
+    }
+
+    if (sheets !== undefined && !WorksheetReader.isValidFilter(sheets)) {
+      throw new IncorrectFlagValue(
+        `🤷‍♂️ Sheets filter have to be string name or array of names, but ${sheets} given`
       );
     }
 

--- a/packages/lokse/src/config.ts
+++ b/packages/lokse/src/config.ts
@@ -1,5 +1,6 @@
 import { cosmiconfigSync } from "cosmiconfig";
 import { NAME, OutputFormat } from "./constants";
+import { SheetsFilter } from "./core/reader/worksheet-reader";
 // TODO: use async API once custom oclif flags will be asynchronous
 const explorerSync = cosmiconfigSync(NAME);
 
@@ -9,6 +10,7 @@ export type ConfigType = {
   languages?: string[];
   column?: string;
   format?: typeof OutputFormat;
+  sheets?: SheetsFilter;
 };
 
 export function get(): undefined | null | ConfigType {

--- a/packages/lokse/src/core/reader/__tests__/worksheet-reader.test.ts
+++ b/packages/lokse/src/core/reader/__tests__/worksheet-reader.test.ts
@@ -7,7 +7,7 @@ const createWorksheet = (title: string, index = 1) => ({
 });
 
 describe("WorksheetReader.shouldUseWorksheet", () => {
-  it("should use worksheet when empty or null or start", () => {
+  it("should use worksheet when empty or null or asterisk", () => {
     const worksheet = createWorksheet("LeTitre") as GoogleSpreadsheetWorksheet;
 
     const reader1 = new WorksheetReader("");
@@ -18,28 +18,32 @@ describe("WorksheetReader.shouldUseWorksheet", () => {
     expect(reader3.shouldUseWorksheet(worksheet)).toEqual(true);
   });
 
-  it("should not use worksheet when title not specified", () => {
+  it("should not use worksheet when title does not match the filter", () => {
     const worksheet = createWorksheet("LeTitre") as GoogleSpreadsheetWorksheet;
 
     const reader1 = new WorksheetReader(["a", "b"]);
     expect(reader1.shouldUseWorksheet(worksheet)).toEqual(false);
     const reader2 = new WorksheetReader(["a", 2]);
     expect(reader2.shouldUseWorksheet(worksheet)).toEqual(false);
+    const reader3 = new WorksheetReader("a");
+    expect(reader3.shouldUseWorksheet(worksheet)).toEqual(false);
   });
 
-  it("should use worksheet when title or index specified", () => {
+  it("should use worksheet when title match the filter exactly", () => {
     const worksheet = createWorksheet("LeTitre") as GoogleSpreadsheetWorksheet;
 
     const reader1 = new WorksheetReader(["a", "LeTitre"]);
     expect(reader1.shouldUseWorksheet(worksheet)).toEqual(true);
     const reader2 = new WorksheetReader(["a", 1]);
     expect(reader2.shouldUseWorksheet(worksheet)).toEqual(true);
+    const reader3 = new WorksheetReader("LeTitre");
+    expect(reader3.shouldUseWorksheet(worksheet)).toEqual(true);
   });
 
-  it("should not use worksheet when filter doesnt pass", () => {
+  it("should use worksheet when title match the filter case insensitive", () => {
     const worksheet = createWorksheet("LeTitre") as GoogleSpreadsheetWorksheet;
 
-    const reader1 = new WorksheetReader("a");
-    expect(reader1.shouldUseWorksheet(worksheet)).toEqual(false);
+    const reader1 = new WorksheetReader(["a", "letitre"]);
+    expect(reader1.shouldUseWorksheet(worksheet)).toEqual(true);
   });
 });

--- a/packages/lokse/src/core/reader/index.ts
+++ b/packages/lokse/src/core/reader/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./spreadsheet-reader";
+export { default as WorksheetReader } from "./worksheet-reader";

--- a/packages/lokse/src/core/reader/spreadsheet-reader.ts
+++ b/packages/lokse/src/core/reader/spreadsheet-reader.ts
@@ -4,7 +4,7 @@ import { CLIError, warn } from "@oclif/errors";
 
 import Line from "../line";
 import { MissingAuthError } from "../errors";
-import WorksheetReader from "./worksheet-reader";
+import WorksheetReader, { SheetsFilter } from "./worksheet-reader";
 import Worksheet from "./worksheet";
 
 export class SpreadsheetReader {
@@ -14,7 +14,7 @@ export class SpreadsheetReader {
 
   private worksheets: Worksheet[] | null;
 
-  constructor(spreadsheetId: string, sheetsFilter?: string | null) {
+  constructor(spreadsheetId: string, sheetsFilter?: SheetsFilter | null) {
     this.spreadsheet = new GoogleSpreadsheet(spreadsheetId);
     this.sheetsReader = new WorksheetReader(sheetsFilter);
 

--- a/packages/lokse/src/core/reader/worksheet-reader.ts
+++ b/packages/lokse/src/core/reader/worksheet-reader.ts
@@ -8,7 +8,7 @@ import Worksheet from "./worksheet";
 
 declare type SheetIndexOrTitle = number | string;
 
-declare type SheetsFilter = string | SheetIndexOrTitle[];
+export declare type SheetsFilter = string | SheetIndexOrTitle[];
 
 class WorksheetReader {
   static ALL_SHEETS_FILTER = "*";

--- a/packages/lokse/src/core/reader/worksheet-reader.ts
+++ b/packages/lokse/src/core/reader/worksheet-reader.ts
@@ -20,6 +20,12 @@ class WorksheetReader {
     this.filter = filter || WorksheetReader.ALL_SHEETS_FILTER;
   }
 
+  static isValidFilter(filter: any): filter is SheetsFilter {
+    return forceArray(filter).every(
+      (f) => typeof f === "string" || typeof f === "number"
+    );
+  }
+
   shouldUseWorksheet(worksheet: GoogleSpreadsheetWorksheet) {
     if (this.filter === WorksheetReader.ALL_SHEETS_FILTER) {
       return true;

--- a/packages/lokse/src/core/reader/worksheet-reader.ts
+++ b/packages/lokse/src/core/reader/worksheet-reader.ts
@@ -3,7 +3,7 @@ import {
   GoogleSpreadsheet,
   GoogleSpreadsheetWorksheet,
 } from "google-spreadsheet";
-import { forceArray } from "../../utils";
+import { forceArray, isEqualCaseInsensitive } from "../../utils";
 import Worksheet from "./worksheet";
 
 declare type SheetIndexOrTitle = number | string;
@@ -30,7 +30,10 @@ class WorksheetReader {
       if (typeof sheetFilter === "number" && worksheet.index === sheetFilter) {
         return true;
       }
-      if (typeof sheetFilter === "string" && worksheet.title === sheetFilter) {
+      if (
+        typeof sheetFilter === "string" &&
+        isEqualCaseInsensitive(worksheet.title, sheetFilter)
+      ) {
         return true;
       }
       return false;

--- a/packages/lokse/src/core/reader/worksheet-reader.ts
+++ b/packages/lokse/src/core/reader/worksheet-reader.ts
@@ -1,4 +1,5 @@
 import { all } from "bluebird";
+import { warn } from "@oclif/errors";
 import {
   GoogleSpreadsheet,
   GoogleSpreadsheetWorksheet,
@@ -50,6 +51,18 @@ class WorksheetReader {
     const worksheets = spreadsheet.sheetsByIndex.filter((worksheet) =>
       this.shouldUseWorksheet(worksheet)
     );
+
+    if (worksheets.length === 0) {
+      let message = `Could find any sheets`;
+
+      if (this.filter !== WorksheetReader.ALL_SHEETS_FILTER) {
+        const existingSheets = Object.keys(spreadsheet.sheetsByTitle);
+
+        message += ` that match the filter ${this.filter.toString()}. Existing sheets are ${existingSheets}`;
+      }
+
+      warn(`${message}. `);
+    }
 
     const sheets = await all(worksheets.map(this.loadSheet));
 

--- a/packages/lokse/src/core/reader/worksheet-reader.ts
+++ b/packages/lokse/src/core/reader/worksheet-reader.ts
@@ -59,7 +59,7 @@ class WorksheetReader {
     );
 
     if (worksheets.length === 0) {
-      let message = `Could find any sheets`;
+      let message = `Couldn't find any sheets`;
 
       if (this.filter !== WorksheetReader.ALL_SHEETS_FILTER) {
         const existingSheets = Object.keys(spreadsheet.sheetsByTitle);


### PR DESCRIPTION
Adds option to specify which sheets from spreadsheet are supossed to use for generating translations. This change precedes to #6.

Fixes #11 