### PR TITLE
Feat/26 sheets excluding

### DIFF
--- a/packages/lokse/README.md
+++ b/packages/lokse/README.md
@@ -1,5 +1,4 @@
-lokse
-===
+# lokse
 
 A tool for efficient usage of translations stored in google spreadsheet
 
@@ -8,14 +7,15 @@ A tool for efficient usage of translations stored in google spreadsheet
 [![Downloads/week](https://img.shields.io/npm/dw/lokse.svg)](https://npmjs.org/package/lokse)
 [![License](https://img.shields.io/npm/l/lokse.svg)](https://github.com/AckeeCZ/lokse/blob/master/package.json)
 
-
-* [Usage](#-usage)
-* [Authentication](#-authentication)
-* [Configuration](#-configuration)
-* [Commands](#-commands)
+- [Usage](#-usage)
+- [Authentication](#-authentication)
+- [Configuration](#-configuration)
+- [Commands](#-commands)
 
 ## 🚀 Usage
+
 <!-- usage -->
+
 ```sh-session
 $ npm install -g lokse
 $ lokse COMMAND
@@ -27,15 +27,17 @@ USAGE
   $ lokse COMMAND
 ...
 ```
+
 <!-- usagestop -->
-## 🔑 Authentication 
+
+## 🔑 Authentication
 
 The last version of Google Spreadsheets API requires us to be authenticated to allow fetching spreadsheet data.
 
 There are two options for authentication: Service Account or API key. For each of these options we have to define some values as environment variables.
 
 ### Environment variables
- 
+
 We have practically two ways of how to define environment variables containing API key or Service Account credentials
 
 Use it before the command like
@@ -44,7 +46,7 @@ Use it before the command like
 $ LOKSE_SERVICE_ACCOUNT_EMAIL=this_is_account_email LOKSE_PRIVATE_KEY=this_is_the_private_key lokse update
 ```
 
-or use a more flexible and handy way of keeping variables inside the `.env.local` file. Create the file if you don't have it yet  and put your variables into it like
+or use a more flexible and handy way of keeping variables inside the `.env.local` file. Create the file if you don't have it yet and put your variables into it like
 
 ```
 LOKSE_SERVICE_ACCOUNT_EMAIL=this_is_account_email
@@ -53,16 +55,15 @@ LOKSE_PRIVATE_KEY=this_is_the_private_key
 
 then you'll be able to run
 
-```sh-session 
+```sh-session
 $ lokse update
 ```
 
 > For the sake of security reasons **Never check your API keys / secrets into version control**. That means you should **not forget to add `.env.local` into the `.gitignore`**.
 
-
 ### Service Account
 
-Currently the best option of authentication is to create a Service account (if you don't have any, follow [the instructions here](https://theoephraim.github.io/node-google-spreadsheet/#/getting-started/authentication?id=service-account)) and then setup at least read permissions for your account in the spreadsheet. 
+Currently the best option of authentication is to create a Service account (if you don't have any, follow [the instructions here](https://theoephraim.github.io/node-google-spreadsheet/#/getting-started/authentication?id=service-account)) and then setup at least read permissions for your account in the spreadsheet.
 
 Since every Service account contains email adress just click the "Share" button at top right corner of the spreadsheet and add your Service account email there.
 
@@ -75,10 +76,9 @@ Once you have the Service account created, you should have its client email and 
 
 Take these two values, put them into `LOKSE_SERVICE_ACCOUNT_EMAIL` and `LOKSE_PRIVATE_KEY` variables using one of two ways [described above](#environment-variables) and there you go, fetching data from spreadsheet should work now.
 
-
 ### API key
 
-For read only access, we're good with usage of API key, if you don't have any, follow [the instructions here](https://theoephraim.github.io/node-google-spreadsheet/#/getting-started/authentication?id=api-key) to create one. 
+For read only access, we're good with usage of API key, if you don't have any, follow [the instructions here](https://theoephraim.github.io/node-google-spreadsheet/#/getting-started/authentication?id=api-key) to create one.
 
 Then define the variable `LOKSE_API_KEY=this_is_your_api_key` and then if the key is valid fetching data should work for you.
 
@@ -86,13 +86,13 @@ Using API key instead of Service account has one important limitation: You sprea
 
 ## 🔧 Configuration
 
-CLI uses [`Cosmiconfig`](https://www.npmjs.com/package/cosmiconfig) which means you can hold the configuration in [any format it supports](https://github.com/davidtheclark/cosmiconfig#cosmiconfig). 
+CLI uses [`Cosmiconfig`](https://www.npmjs.com/package/cosmiconfig) which means you can hold the configuration in [any format it supports](https://github.com/davidtheclark/cosmiconfig#cosmiconfig).
 
 So just create `lokse.config.js`, `.lokserc`, `.lokserc.yml`, `.lokserc.json` or add `lokse` property into the `package.json` and there you can setup on of the options:
 
 ### `sheetId`
 
-Spreadsheet id. When you open your spreadsheet it's this string   
+Spreadsheet id. When you open your spreadsheet it's this string  
 ![](https://raw.githubusercontent.com/AckeeCZ/lokse/master/doc/spreadsheet-id.png)
 
 ### `dir`
@@ -113,18 +113,62 @@ Format of output translation file.
 
 ### `sheets`
 
-Titles of sheets to use. Can be string or array of string. If none provided, all sheets are used.
+Target spreadsheet can contain more than one sheet and default behaviour is to use all of them, but sometimes you need only some of them. This option determines sheets to fetch translations from. You can define sheets you want to use or those you don't want to or combine these definition.
 
+You can choose from various formats to define sheets to use
+
+1. Special value `*` means to include all sheets and is the default behaviour when you omit the `sheets` option.
+  
+    ```json
+    {
+      "sheets": "*",
+    }
+    ```
+
+2. Titles of sheets to use. Can be string or array of strings
+  
+    ```json
+      {
+        "sheets": "Web translations",
+      }
+      // or
+      {
+        "sheets": ["App translations", "Legal docs"]
+      }
+    ```
+
+3. Definition of sheets to include or exclude from the list of all sheets. Can be one of formats mentioned above
+  
+    ```json
+      {
+        "sheets": {
+          "include": ["Web translations", "Legal docs"],
+          "exclude": "CMS translations"
+        }
+      }
+      // or
+      {
+        "sheets": {
+          "exclude": ["CMS translations"]
+        }
+      }
+      // or 
+      {
+        "sheets": {
+          "include": ["Web translations", "Legal docs"],
+        }
+      }
+    ```
 ### `splitTranslations`
 
-Enables splitting translations into multiple files which is useful for lazy loading of some big parts of translations (eg. translation of the whole legal document). 
+Enables splitting translations into multiple files which is useful for lazy loading of some big parts of translations (eg. translation of the whole legal document).
 
 You have two ways of how to split your translations:
 
-* **Split by sheets - `splitTranslations: true`** - each sheet means one translations file and name of file is determined by sheet title. Given 3 sheets in yout spreadsheet named "App translations", "Legal docs", "Landing Page" the result will be 3 files named `app-translations.cs.json`, `legal-docs.cs.json`, `landing-page.cs.json` (of course the language and format depends on your settings).  
+- **Split by sheets - `splitTranslations: true`** - each sheet means one translations file and name of file is determined by sheet title. Given 3 sheets in yout spreadsheet named "App translations", "Legal docs", "Landing Page" the result will be 3 files named `app-translations.cs.json`, `legal-docs.cs.json`, `landing-page.cs.json` (of course the language and format depends on your settings).
 
-* **Split by domains - `splitTranslations: string[]`** - this configuration expects an array of domain names. Domain is a first part of your translation id, given translation id `news.mostRead.error.text` the domain is `news`. The domain name determines also the filename, `news.cs.json` in our example.  
-Translations that starts with domain `news.` will be written into the `news.cs.json`, other translations that does not belong to any other group will be saved into general translations in file `cs.json`.
+- **Split by domains - `splitTranslations: string[]`** - this configuration expects an array of domain names. Domain is a first part of your translation id, given translation id `news.mostRead.error.text` the domain is `news`. The domain name determines also the filename, `news.cs.json` in our example.  
+  Translations that starts with domain `news.` will be written into the `news.cs.json`, other translations that does not belong to any other group will be saved into general translations in file `cs.json`.
 
 The `splitTranslations` option can be provided only through configuration not inline CLI parameter.
 
@@ -136,11 +180,7 @@ The `splitTranslations` option can be provided only through configuration not in
 {
   "sheetId": "1HKjvejcuHIY73WvEkipD7_dmF9dFeNLji3nS2RXcIzk",
   "dir": "locales",
-  "languages": [
-    "cs",
-    "en",
-    "fr"
-  ],
+  "languages": ["cs", "en", "fr"],
   "column": "key_web",
   "format": "json",
   "sheets": ["App translations", "Legal docs"],
@@ -148,11 +188,13 @@ The `splitTranslations` option can be provided only through configuration not in
 }
 ```
 
-## 🕹 Commands 
+## 🕹 Commands
+
 <!-- commands -->
-* [`lokse help [COMMAND]`](#lokse-help-command)
-* [`lokse open`](#lokse-open)
-* [`lokse update`](#lokse-update)
+
+- [`lokse help [COMMAND]`](#lokse-help-command)
+- [`lokse open`](#lokse-open)
+- [`lokse update`](#lokse-update)
 
 ## `lokse help [COMMAND]`
 

--- a/packages/lokse/jest.config.js
+++ b/packages/lokse/jest.config.js
@@ -16,4 +16,9 @@ module.exports = {
       statements: 100,
     },
   },
+  globals: {
+    "ts-jest": {
+      diagnostics: { warnOnly: true },
+    },
+  },
 };

--- a/packages/lokse/package.json
+++ b/packages/lokse/package.json
@@ -24,6 +24,7 @@
     "dedent": "^0.7.0",
     "dotenv-flow": "^3.2.0",
     "google-spreadsheet": "^3.0.13",
+    "lodash": "^4.17.20",
     "mkdirp": "^1.0.4",
     "open": "^7.2.1",
     "ora": "^5.0.0",

--- a/packages/lokse/src/commands/__tests__/update.test.ts
+++ b/packages/lokse/src/commands/__tests__/update.test.ts
@@ -5,7 +5,7 @@ import { when } from "jest-when";
 
 import Reader from "../../core/reader/spreadsheet-reader";
 import WorksheetReader, {
-  InvalidFilter,
+  InvalidFilterError,
 } from "../../core/reader/worksheet-reader";
 import { FileWriter } from "../../core/writer";
 import { OutputFormat } from "../../constants";
@@ -204,7 +204,7 @@ describe("update command", () => {
         explorerMock.search.mockReturnValue({ config: { sheets: true } });
 
         WorksheetReaderMock.mockImplementationOnce(() => {
-          throw new InvalidFilter(true);
+          throw new InvalidFilterError(true);
         });
       })
       .command(["update", ...Object.values(params)])

--- a/packages/lokse/src/commands/__tests__/update.test.ts
+++ b/packages/lokse/src/commands/__tests__/update.test.ts
@@ -4,6 +4,9 @@ import * as dedent from "dedent";
 import { when } from "jest-when";
 
 import Reader from "../../core/reader/spreadsheet-reader";
+import WorksheetReader, {
+  InvalidFilter,
+} from "../../core/reader/worksheet-reader";
 import { FileWriter } from "../../core/writer";
 import { OutputFormat } from "../../constants";
 import { noExitCliInvariant } from "../../utils";
@@ -39,6 +42,14 @@ ReaderMock.mockReturnValue({
   read: mockRead,
 });
 
+// Worksheet reader mock
+jest.mock("../../core/reader/worksheet-reader");
+const mockWorksheetRead = jest.fn();
+const WorksheetReaderMock = (WorksheetReader as any) as jest.Mock;
+WorksheetReaderMock.mockReturnValue({
+  read: mockWorksheetRead,
+});
+
 const outputFormats = Object.values(OutputFormat).join(", ");
 
 describe("update command", () => {
@@ -63,6 +74,7 @@ describe("update command", () => {
     /* eslint-disable no-console */
     run() {
       ReaderMock.mockClear();
+      WorksheetReaderMock.mockClear();
       mockRead.mockClear().mockReturnValue(mockSheetLines);
       FileWriterMock.mockClear();
       mockWrite.mockClear();
@@ -154,68 +166,152 @@ describe("update command", () => {
       expect(ReaderMock.mock.instances[0][1]).toBeUndefined();
     });
 
-  test
-    .setupMocks()
-    .command(["update", ...Object.values(params), "--sheets=Main translations"])
-    .it("uses filter when only one name supplied", () => {
-      expect(ReaderMock.mock.instances).toHaveLength(1);
-      expect(ReaderMock.mock.calls[0][1]).toEqual(["Main translations"]);
-    });
+  describe("Sheets filter", () => {
+    test
+      .setupMocks()
+      .command([
+        "update",
+        ...Object.values(params),
+        "--sheets=Main translations",
+      ])
+      .it("uses filter when only one name supplied", () => {
+        expect(WorksheetReaderMock.mock.instances).toHaveLength(1);
+        expect(WorksheetReaderMock.mock.calls[0][0]).toEqual([
+          "Main translations",
+        ]);
+        expect(ReaderMock).toHaveBeenCalled();
+      });
 
-  test
-    .setupMocks()
-    .command([
-      "update",
-      ...Object.values(params),
-      "--sheets=Main translations,Secondary translations",
-    ])
-    .it("parses and uses filter when list of names supplied", () => {
-      expect(ReaderMock.mock.instances).toHaveLength(1);
-      expect(ReaderMock.mock.calls[0][1]).toEqual([
-        "Main translations",
-        "Secondary translations",
-      ]);
-    });
+    test
+      .setupMocks()
+      .command([
+        "update",
+        ...Object.values(params),
+        "--sheets=Main translations,Secondary translations",
+      ])
+      .it("parses and uses filter when list of names supplied", () => {
+        expect(WorksheetReaderMock.mock.instances).toHaveLength(1);
+        expect(WorksheetReaderMock.mock.calls[0][0]).toEqual([
+          "Main translations",
+          "Secondary translations",
+        ]);
+        expect(ReaderMock).toHaveBeenCalled();
+      });
 
-  test
-    .setupMocks()
-    .do(() => explorerMock.search.mockReturnValue({ config: { sheets: true } }))
-    .command(["update", ...Object.values(params)])
-    .catch((error) => {
-      expect(error.message).toEqual(
-        `🤷‍♂️ Sheets filter have to be string name or array of names, but ${true} given`
+    test
+      .setupMocks()
+      .do(() => {
+        explorerMock.search.mockReturnValue({ config: { sheets: true } });
+
+        WorksheetReaderMock.mockImplementationOnce(() => {
+          throw new InvalidFilter(true);
+        });
+      })
+      .command(["update", ...Object.values(params)])
+      .catch((error) => {
+        expect(error).not.toBeFalsy();
+        expect(WorksheetReaderMock).toHaveBeenCalled();
+        expect(WorksheetReaderMock.mock.calls[0][0]).toEqual(true);
+        expect(ReaderMock).not.toHaveBeenCalled();
+      })
+      .it("throws when filter has invalid format");
+
+    test
+      .setupMocks()
+      .do(() =>
+        explorerMock.search.mockReturnValue({
+          config: { sheets: "Secondary translations" },
+        })
+      )
+      .command(["update", ...Object.values(params)])
+      .it("uses string filter supplied through config", () => {
+        expect(WorksheetReaderMock.mock.instances).toHaveLength(1);
+        expect(WorksheetReaderMock.mock.calls[0][0]).toEqual(
+          "Secondary translations"
+        );
+        expect(ReaderMock).toHaveBeenCalled();
+      });
+
+    test
+      .setupMocks()
+      .do(() =>
+        explorerMock.search.mockReturnValue({
+          config: { sheets: ["Main translations", "Secondary translations"] },
+        })
+      )
+      .command(["update", ...Object.values(params)])
+      .it("uses names list filter supplied through config", () => {
+        expect(WorksheetReaderMock.mock.instances).toHaveLength(1);
+        expect(WorksheetReaderMock.mock.calls[0][0]).toEqual([
+          "Main translations",
+          "Secondary translations",
+        ]);
+        expect(ReaderMock).toHaveBeenCalled();
+      });
+
+    test
+      .setupMocks()
+      .do(() =>
+        explorerMock.search.mockReturnValue({
+          config: {
+            sheets: {
+              include: ["Main translations", "Other translations"],
+            },
+          },
+        })
+      )
+      .command(["update", ...Object.values(params)])
+      .it("uses include only filter supplied through config", () => {
+        expect(WorksheetReaderMock.mock.instances).toHaveLength(1);
+        expect(WorksheetReaderMock.mock.calls[0][0]).toEqual({
+          include: ["Main translations", "Other translations"],
+        });
+        expect(ReaderMock).toHaveBeenCalled();
+      });
+
+    test
+      .setupMocks()
+      .do(() =>
+        explorerMock.search.mockReturnValue({
+          config: {
+            sheets: {
+              exclude: ["Main translations", "Other translations"],
+            },
+          },
+        })
+      )
+      .command(["update", ...Object.values(params)])
+      .it("uses exclude only filter supplied through config", () => {
+        expect(WorksheetReaderMock.mock.instances).toHaveLength(1);
+        expect(WorksheetReaderMock.mock.calls[0][0]).toEqual({
+          exclude: ["Main translations", "Other translations"],
+        });
+      });
+
+    test
+      .setupMocks()
+      .do(() =>
+        explorerMock.search.mockReturnValue({
+          config: {
+            sheets: {
+              include: "Main translations",
+              exclude: ["Other translations", "Non web translations"],
+            },
+          },
+        })
+      )
+      .command(["update", ...Object.values(params)])
+      .it(
+        "uses mixed include and exclude filter supplied through config",
+        () => {
+          expect(WorksheetReaderMock.mock.instances).toHaveLength(1);
+          expect(WorksheetReaderMock.mock.calls[0][0]).toEqual({
+            include: "Main translations",
+            exclude: ["Other translations", "Non web translations"],
+          });
+        }
       );
-    })
-    .it("throws when filter is not a string or list of string");
-
-  test
-    .setupMocks()
-    .do(() =>
-      explorerMock.search.mockReturnValue({
-        config: { sheets: "Secondary translations" },
-      })
-    )
-    .command(["update", ...Object.values(params)])
-    .it("uses string filter supplied through config", () => {
-      expect(ReaderMock.mock.instances).toHaveLength(1);
-      expect(ReaderMock.mock.calls[0][1]).toEqual("Secondary translations");
-    });
-
-  test
-    .setupMocks()
-    .do(() =>
-      explorerMock.search.mockReturnValue({
-        config: { sheets: ["Main translations", "Secondary translations"] },
-      })
-    )
-    .command(["update", ...Object.values(params)])
-    .it("uses names list filter supplied through config", () => {
-      expect(ReaderMock.mock.instances).toHaveLength(1);
-      expect(ReaderMock.mock.calls[0][1]).toEqual([
-        "Main translations",
-        "Secondary translations",
-      ]);
-    });
+  });
 
   test
     .setupMocks()
@@ -696,7 +792,7 @@ describe("update command", () => {
             mockSheetLines2,
             expect.anything()
           );
-          
+
           expect(mockOraInstance.succeed).toHaveBeenNthCalledWith(
             2,
             dedent`All ${languages[1]} translations saved into ${translationsDir}

--- a/packages/lokse/src/commands/update.ts
+++ b/packages/lokse/src/commands/update.ts
@@ -8,7 +8,11 @@ import * as flat from "array.prototype.flat";
 import { NAME } from "../constants";
 import Base from "../base";
 import { OutputFormat } from "../constants";
-import Reader, { WorksheetReader, WorksheetLinesByTitle } from "../core/reader";
+import Reader, {
+  WorksheetReader,
+  WorksheetLinesByTitle,
+  InvalidFilter,
+} from "../core/reader";
 import { transformersByFormat } from "../core/transformer";
 import { FileWriter } from "../core/writer";
 import Line from "../core/line";
@@ -148,15 +152,21 @@ class Update extends Base {
       );
     }
 
-    if (sheets !== undefined && !WorksheetReader.isValidFilter(sheets)) {
-      throw new IncorrectFlagValue(
-        `🤷‍♂️ Sheets filter have to be string name or array of names, but ${sheets} given`
-      );
+    let worksheetReader;
+
+    try {
+      worksheetReader = new WorksheetReader(sheets);
+    } catch (error) {
+      if (error instanceof InvalidFilter) {
+        throw new IncorrectFlagValue(error.message);
+      } else {
+        throw error;
+      }
     }
 
     const outputTransformer = transformersByFormat[format];
 
-    const reader = new Reader(sheetId, sheets);
+    const reader = new Reader(sheetId, worksheetReader);
     const writer = new FileWriter();
 
     const outputDir = path.resolve(process.cwd(), dir);

--- a/packages/lokse/src/commands/update.ts
+++ b/packages/lokse/src/commands/update.ts
@@ -11,7 +11,7 @@ import { OutputFormat } from "../constants";
 import Reader, {
   WorksheetReader,
   WorksheetLinesByTitle,
-  InvalidFilter,
+  InvalidFilterError,
 } from "../core/reader";
 import { transformersByFormat } from "../core/transformer";
 import { FileWriter } from "../core/writer";
@@ -157,7 +157,7 @@ class Update extends Base {
     try {
       worksheetReader = new WorksheetReader(sheets);
     } catch (error) {
-      if (error instanceof InvalidFilter) {
+      if (error instanceof InvalidFilterError) {
         throw new IncorrectFlagValue(error.message);
       } else {
         throw error;

--- a/packages/lokse/src/core/reader/__tests__/worksheet-reader.test.ts
+++ b/packages/lokse/src/core/reader/__tests__/worksheet-reader.test.ts
@@ -6,6 +6,75 @@ const createWorksheet = (title: string, index = 1) => ({
   index,
 });
 
+describe("WorksheetReader - filter normalization", () => {
+  it("normalize empty filter to all sheets filter", () => {
+    const includeAllFilter = {
+      include: ["*"],
+      exclude: [],
+    };
+
+    const reader1 = new WorksheetReader("");
+    expect(reader1.filter).toEqual(includeAllFilter);
+    const reader2 = new WorksheetReader(null);
+    expect(reader2.filter).toEqual(includeAllFilter);
+  });
+
+  it("normalize all filter to include all sheets filter", () => {
+    const reader1 = new WorksheetReader("*");
+    expect(reader1.filter).toEqual({
+      include: ["*"],
+      exclude: [],
+    });
+  });
+
+  it("normalize string filter", () => {
+    const reader1 = new WorksheetReader("laRusso");
+    expect(reader1.filter).toEqual({
+      include: ["laRusso"],
+      exclude: [],
+    });
+  });
+
+  it("normalize array filter", () => {
+    const reader1 = new WorksheetReader(["a", "b"]);
+    expect(reader1.filter).toEqual({
+      include: ["a", "b"],
+      exclude: [],
+    });
+    const reader2 = new WorksheetReader(["a", 2]);
+    expect(reader2.filter).toEqual({
+      include: ["a", 2],
+      exclude: [],
+    });
+  });
+
+  it("normalize complex filter without include", () => {
+    const reader1 = new WorksheetReader({ exclude: "foo" });
+    expect(reader1.filter).toEqual({
+      include: ["*"],
+      exclude: ["foo"],
+    });
+  });
+
+  it("normalize complex filter without exclude", () => {
+    const reader1 = new WorksheetReader({ include: "bar" });
+    expect(reader1.filter).toEqual({
+      include: ["bar"],
+      exclude: [],
+    });
+  });
+
+  it("normalize complex filter without include or exclude to include all sheets filter", () => {
+    const reader1 = new WorksheetReader({});
+    expect(reader1.filter).toEqual({
+      include: ["*"],
+      exclude: [],
+    });
+  });
+
+  it.todo("throws when unsupported filter type provided");
+});
+
 describe("WorksheetReader.shouldUseWorksheet", () => {
   it("should use worksheet when empty or null or asterisk", () => {
     const worksheet = createWorksheet("LeTitre") as GoogleSpreadsheetWorksheet;
@@ -18,32 +87,77 @@ describe("WorksheetReader.shouldUseWorksheet", () => {
     expect(reader3.shouldUseWorksheet(worksheet)).toEqual(true);
   });
 
-  it("should not use worksheet when title does not match the filter", () => {
+  it("should not use worksheet when title does not match the include the filter", () => {
     const worksheet = createWorksheet("LeTitre") as GoogleSpreadsheetWorksheet;
 
-    const reader1 = new WorksheetReader(["a", "b"]);
+    const reader1 = new WorksheetReader({ include: ["a", "b"] });
     expect(reader1.shouldUseWorksheet(worksheet)).toEqual(false);
-    const reader2 = new WorksheetReader(["a", 2]);
+    const reader2 = new WorksheetReader({ include: ["a", 2] });
     expect(reader2.shouldUseWorksheet(worksheet)).toEqual(false);
-    const reader3 = new WorksheetReader("a");
+    const reader3 = new WorksheetReader({ include: "a" });
     expect(reader3.shouldUseWorksheet(worksheet)).toEqual(false);
   });
 
-  it("should use worksheet when title match the filter exactly", () => {
+  it("should use worksheet when title match the include filter exactly", () => {
     const worksheet = createWorksheet("LeTitre") as GoogleSpreadsheetWorksheet;
 
-    const reader1 = new WorksheetReader(["a", "LeTitre"]);
+    const reader1 = new WorksheetReader({ include: ["a", "LeTitre"] });
     expect(reader1.shouldUseWorksheet(worksheet)).toEqual(true);
-    const reader2 = new WorksheetReader(["a", 1]);
+    const reader2 = new WorksheetReader({ include: ["a", 1] });
     expect(reader2.shouldUseWorksheet(worksheet)).toEqual(true);
-    const reader3 = new WorksheetReader("LeTitre");
+    const reader3 = new WorksheetReader({ include: "LeTitre" });
     expect(reader3.shouldUseWorksheet(worksheet)).toEqual(true);
   });
 
-  it("should use worksheet when title match the filter case insensitive", () => {
+  it("should use worksheet when title match the include filter case insensitive", () => {
     const worksheet = createWorksheet("LeTitre") as GoogleSpreadsheetWorksheet;
 
-    const reader1 = new WorksheetReader(["a", "letitre"]);
+    const reader1 = new WorksheetReader({ include: ["a", "letitre"] });
     expect(reader1.shouldUseWorksheet(worksheet)).toEqual(true);
   });
+
+  it("should not use worksheet when title match exclude filter", () => {
+    const worksheet = createWorksheet("AppTrans") as GoogleSpreadsheetWorksheet;
+
+    const reader1 = new WorksheetReader({
+      exclude: "AppTrans",
+    });
+    expect(reader1.shouldUseWorksheet(worksheet)).toEqual(false);
+    const reader2 = new WorksheetReader({
+      exclude: ["AppTrans", "API Trans"],
+    });
+    expect(reader2.shouldUseWorksheet(worksheet)).toEqual(false);
+  });
+
+  it("should use worksheet when title doesnt match exclude filter and include not available", () => {
+    const worksheet = createWorksheet("WebTrans") as GoogleSpreadsheetWorksheet;
+
+    const reader1 = new WorksheetReader({
+      exclude: "AppTrans",
+    });
+    expect(reader1.shouldUseWorksheet(worksheet)).toEqual(true);
+    const reader2 = new WorksheetReader({
+      exclude: ["AppTrans", "API Trans"],
+    });
+    expect(reader2.shouldUseWorksheet(worksheet)).toEqual(true);
+  });
+
+  it("should not use worksheet when title does not match include filter nor exclude filter", () => {
+    const worksheet = createWorksheet("APITrans") as GoogleSpreadsheetWorksheet;
+
+    const reader1 = new WorksheetReader({
+      include: "MyTrans",
+      exclude: "App Trans",
+    });
+    expect(reader1.shouldUseWorksheet(worksheet)).toEqual(false);
+    const reader2 = new WorksheetReader({
+      include: ["MyTrans"],
+      exclude: ["App Trans"],
+    });
+    expect(reader2.shouldUseWorksheet(worksheet)).toEqual(false);
+  });
+
+  it.todo(
+    "should use worksheet and warn when title pass include and also exclude filter"
+  );
 });

--- a/packages/lokse/src/core/reader/__tests__/worksheet-reader.test.ts
+++ b/packages/lokse/src/core/reader/__tests__/worksheet-reader.test.ts
@@ -1,5 +1,5 @@
 import { GoogleSpreadsheetWorksheet } from "google-spreadsheet";
-import WorksheetReader, { InvalidFilter } from "../worksheet-reader";
+import WorksheetReader, { InvalidFilterError } from "../worksheet-reader";
 
 const createWorksheet = (title: string, index = 1) => ({
   title,
@@ -73,9 +73,9 @@ describe("WorksheetReader - filter normalization", () => {
   });
 
   it("throws when unsupported filter type provided", () => {
-    expect(() => new WorksheetReader(true)).toThrowError(InvalidFilter);
-    expect(() => new WorksheetReader(3)).toThrowError(InvalidFilter);
-    expect(() => new WorksheetReader(new Date)).toThrowError(InvalidFilter);
+    expect(() => new WorksheetReader(true)).toThrowError(InvalidFilterError);
+    expect(() => new WorksheetReader(3)).toThrowError(InvalidFilterError);
+    expect(() => new WorksheetReader(new Date)).toThrowError(InvalidFilterError);
   });
 });
 

--- a/packages/lokse/src/core/reader/__tests__/worksheet-reader.test.ts
+++ b/packages/lokse/src/core/reader/__tests__/worksheet-reader.test.ts
@@ -1,5 +1,5 @@
 import { GoogleSpreadsheetWorksheet } from "google-spreadsheet";
-import WorksheetReader from "../worksheet-reader";
+import WorksheetReader, { InvalidFilter } from "../worksheet-reader";
 
 const createWorksheet = (title: string, index = 1) => ({
   title,
@@ -72,7 +72,11 @@ describe("WorksheetReader - filter normalization", () => {
     });
   });
 
-  it.todo("throws when unsupported filter type provided");
+  it("throws when unsupported filter type provided", () => {
+    expect(() => new WorksheetReader(true)).toThrowError(InvalidFilter);
+    expect(() => new WorksheetReader(3)).toThrowError(InvalidFilter);
+    expect(() => new WorksheetReader(new Date)).toThrowError(InvalidFilter);
+  });
 });
 
 describe("WorksheetReader.shouldUseWorksheet", () => {

--- a/packages/lokse/src/core/reader/index.ts
+++ b/packages/lokse/src/core/reader/index.ts
@@ -1,2 +1,2 @@
 export { default, WorksheetLinesByTitle } from "./spreadsheet-reader";
-export { default as WorksheetReader, InvalidFilter } from "./worksheet-reader";
+export { default as WorksheetReader, InvalidFilterError } from "./worksheet-reader";

--- a/packages/lokse/src/core/reader/index.ts
+++ b/packages/lokse/src/core/reader/index.ts
@@ -1,2 +1,2 @@
 export { default, WorksheetLinesByTitle } from "./spreadsheet-reader";
-export { default as WorksheetReader } from "./worksheet-reader";
+export { default as WorksheetReader, InvalidFilter } from "./worksheet-reader";

--- a/packages/lokse/src/core/reader/spreadsheet-reader.ts
+++ b/packages/lokse/src/core/reader/spreadsheet-reader.ts
@@ -3,7 +3,7 @@ import { CLIError, warn } from "@oclif/errors";
 
 import Line from "../line";
 import { MissingAuthError } from "../errors";
-import WorksheetReader, { SheetsFilter } from "./worksheet-reader";
+import WorksheetReader from "./worksheet-reader";
 import Worksheet from "./worksheet";
 
 export declare type WorksheetLinesByTitle = {
@@ -17,9 +17,9 @@ export class SpreadsheetReader {
 
   private worksheets: Worksheet[] | null;
 
-  constructor(spreadsheetId: string, sheetsFilter?: SheetsFilter | null) {
+  constructor(spreadsheetId: string, sheetsReader: WorksheetReader) {
     this.spreadsheet = new GoogleSpreadsheet(spreadsheetId);
-    this.sheetsReader = new WorksheetReader(sheetsFilter);
+    this.sheetsReader = sheetsReader;
 
     this.worksheets = null;
   }

--- a/packages/lokse/src/core/reader/worksheet-reader.ts
+++ b/packages/lokse/src/core/reader/worksheet-reader.ts
@@ -8,6 +8,16 @@ import {
 import { forceArray, isEqualCaseInsensitive } from "../../utils";
 import Worksheet from "./worksheet";
 
+export class InvalidFilter extends Error {
+  constructor(filter: any) {
+    super(
+      `💥 Invalid sheets filter provided: ${JSON.stringify(
+        filter
+      )}. Look at the supported filter format reference.`
+    );
+  }
+}
+
 type SheetTitle = string;
 
 type SheetIndexOrTitle = number | SheetTitle;
@@ -58,14 +68,7 @@ class WorksheetReader {
       };
     }
 
-    // TODO: better error
-    throw new Error("unknown filter type");
-  }
-
-  static isValidFilter(filter: any): filter is SheetsFilter {
-    return forceArray(filter).every(
-      (f) => typeof f === "string" || typeof f === "number"
-    );
+    throw new InvalidFilter(filter);
   }
 
   static isSheetInTheList(

--- a/packages/lokse/src/core/reader/worksheet-reader.ts
+++ b/packages/lokse/src/core/reader/worksheet-reader.ts
@@ -8,7 +8,7 @@ import {
 import { forceArray, isEqualCaseInsensitive } from "../../utils";
 import Worksheet from "./worksheet";
 
-export class InvalidFilter extends Error {
+export class InvalidFilterError extends Error {
   public filterStringified: string;
 
   constructor(filter: any) {
@@ -71,7 +71,7 @@ class WorksheetReader {
       };
     }
 
-    throw new InvalidFilter(filter);
+    throw new InvalidFilterError(filter);
   }
 
   static isSheetInTheList(

--- a/packages/lokse/src/core/reader/worksheet-reader.ts
+++ b/packages/lokse/src/core/reader/worksheet-reader.ts
@@ -9,12 +9,15 @@ import { forceArray, isEqualCaseInsensitive } from "../../utils";
 import Worksheet from "./worksheet";
 
 export class InvalidFilter extends Error {
+  public filterStringified: string;
+
   constructor(filter: any) {
+    const filterStringified = JSON.stringify(filter);
     super(
-      `💥 Invalid sheets filter provided: ${JSON.stringify(
-        filter
-      )}. Look at the supported filter format reference.`
+      `💥 Invalid sheets filter provided: ${filterStringified}. Look at the supported filter format reference.`
     );
+
+    this.filterStringified = filterStringified;
   }
 }
 


### PR DESCRIPTION
Extend `sheets` configuration option to allow inverted sheets definition - sheets to exclude. 

* The change is backward compatible
* Both definition `include` and `exclude` can be combined

Fixes #26 