### PR TITLE
Refactor/core package pure

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -30,57 +30,7 @@ USAGE
 
 ## 🔑 Authentication
 
-The last version of Google Spreadsheets API requires us to be authenticated to allow fetching spreadsheet data.
-
-There are two options for authentication: Service Account or API key. For each of these options we have to define some values as environment variables.
-
-### Environment variables
-
-We have practically two ways of how to define environment variables containing API key or Service Account credentials
-
-Use it before the command like
-
-```sh-session
-$ LOKSE_SERVICE_ACCOUNT_EMAIL=this_is_account_email LOKSE_PRIVATE_KEY=this_is_the_private_key lokse update
-```
-
-or use a more flexible and handy way of keeping variables inside the `.env.local` file. Create the file if you don't have it yet and put your variables into it like
-
-```
-LOKSE_SERVICE_ACCOUNT_EMAIL=this_is_account_email
-LOKSE_PRIVATE_KEY=this_is_the_private_key
-```
-
-then you'll be able to run
-
-```sh-session
-$ lokse update
-```
-
-> For the sake of security reasons **Never check your API keys / secrets into version control**. That means you should **not forget to add `.env.local` into the `.gitignore`**.
-
-### Service Account
-
-Currently the best option of authentication is to create a Service account (if you don't have any, follow [the instructions here](https://theoephraim.github.io/node-google-spreadsheet/#/getting-started/authentication?id=service-account)) and then setup at least read permissions for your account in the spreadsheet.
-
-Since every Service account contains email adress just click the "Share" button at top right corner of the spreadsheet and add your Service account email there.
-
-Once you have the Service account created, you should have its client email and private key. It looks smilar to this
-
-```
-"client_email": "localize-with-spreadsheet@localize-with-spreadsheet.iam.gserviceaccount.com",
-"private_key": "-----BEGIN PRIVATE KEY-----\nAnd_here_is_a_long_text_of_random_characters_that_defines_the_private_key\n-----END PRIVATE KEY-----\n",
-```
-
-Take these two values, put them into `LOKSE_SERVICE_ACCOUNT_EMAIL` and `LOKSE_PRIVATE_KEY` variables using one of two ways [described above](#environment-variables) and there you go, fetching data from spreadsheet should work now.
-
-### API key
-
-For read only access, we're good with usage of API key, if you don't have any, follow [the instructions here](https://theoephraim.github.io/node-google-spreadsheet/#/getting-started/authentication?id=api-key) to create one.
-
-Then define the variable `LOKSE_API_KEY=this_is_your_api_key` and then if the key is valid fetching data should work for you.
-
-Using API key instead of Service account has one important limitation: You spreadsheet must set permissions to be visible for everyone in the Internet.
+The last version of Google Spreadsheets API requires us to be authenticated to allow fetching spreadsheet data. Read more about [authentication here](https://github.com/AckeeCZ/lokse/tree/master/packages/core/doc/authentication.md)
 
 ## 🔧 Configuration
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,7 @@
     "@lokse/core": "^1.7.0",
     "@oclif/command": "^1",
     "@oclif/config": "^1",
+    "@oclif/errors": "^1.3.4",
     "@oclif/plugin-help": "^3",
     "@sindresorhus/slugify": "^1.1.0",
     "@types/array.prototype.flat": "^1.2.1",

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import { flags } from "@oclif/command";
+import { CLIError } from "@oclif/errors";
 import * as ora from "ora";
 import * as slugify from "@sindresorhus/slugify";
 import * as dedent from "dedent";
@@ -12,6 +13,7 @@ import {
   transformersByFormat,
   FileWriter,
   Line,
+  FatalError,
 } from "@lokse/core";
 import { WorksheetLinesByTitle } from "@lokse/core";
 
@@ -126,6 +128,7 @@ class Update extends Base {
     this.error("💥 Unknown error occured when splitting translations");
   }
 
+  // eslint-disable-next-line complexity
   async run() {
     const { flags } = this.parse(Update);
 
@@ -247,8 +250,11 @@ class Update extends Base {
       } catch (error) {
         spinner.fail(`Generating ${langName} translations failed.`);
 
-        this.error(error, {
-          exit: error?.oclif?.exit,
+        const normalizedError =
+          error instanceof FatalError ? new CLIError(error) : error;
+
+        this.error(normalizedError, {
+          exit: normalizedError?.oclif?.exit,
         });
       }
     }

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -16,6 +16,7 @@ import {
 import { WorksheetLinesByTitle } from "@lokse/core";
 
 import { NAME } from "../constants";
+import logger from "../logger";
 import Base from "../base";
 
 import * as cliFlags from "../flags";
@@ -156,7 +157,7 @@ class Update extends Base {
     let worksheetReader;
 
     try {
-      worksheetReader = new WorksheetReader(sheets);
+      worksheetReader = new WorksheetReader(sheets, { logger });
     } catch (error) {
       if (error instanceof InvalidFilterError) {
         throw new IncorrectFlagValue(error.message);
@@ -167,7 +168,9 @@ class Update extends Base {
 
     const outputTransformer = transformersByFormat[format];
 
-    const reader = new Reader(sheetId, worksheetReader);
+    const reader = new Reader(sheetId, worksheetReader, {
+      logger,
+    });
     const writer = new FileWriter();
 
     const outputDir = path.resolve(process.cwd(), dir);

--- a/packages/cli/src/logger.ts
+++ b/packages/cli/src/logger.ts
@@ -1,0 +1,10 @@
+import type { Logger } from "@lokse/core";
+
+import { warn } from "@oclif/errors";
+
+const logger: Logger = {
+  ...console,
+  warn,
+};
+
+export default logger;

--- a/packages/core/doc/authentication.md
+++ b/packages/core/doc/authentication.md
@@ -1,0 +1,51 @@
+# 🔑 Authentication
+
+There are two options for authentication: Service Account or API key. For each of these options we have to define some values as environment variables.
+
+## Environment variables
+
+We have practically two ways of how to define environment variables containing API key or Service Account credentials
+
+Use it before the command like
+
+```sh-session
+$ LOKSE_SERVICE_ACCOUNT_EMAIL=this_is_account_email LOKSE_PRIVATE_KEY=this_is_the_private_key lokse update
+```
+
+or use a more flexible and handy way of keeping variables inside the `.env.local` file. Create the file if you don't have it yet and put your variables into it like
+
+```
+LOKSE_SERVICE_ACCOUNT_EMAIL=this_is_account_email
+LOKSE_PRIVATE_KEY=this_is_the_private_key
+```
+
+then you'll be able to run
+
+```sh-session
+$ lokse update
+```
+
+> For the sake of security reasons **Never check your API keys / secrets into version control**. That means you should **not forget to add `.env.local` into the `.gitignore`**.
+
+## Service Account
+
+Currently the best option of authentication is to create a Service account (if you don't have any, follow [the instructions here](https://theoephraim.github.io/node-google-spreadsheet/#/getting-started/authentication?id=service-account)) and then setup at least read permissions for your account in the spreadsheet.
+
+Since every Service account contains email adress just click the "Share" button at top right corner of the spreadsheet and add your Service account email there.
+
+Once you have the Service account created, you should have its client email and private key. It looks smilar to this
+
+```
+"client_email": "localize-with-spreadsheet@localize-with-spreadsheet.iam.gserviceaccount.com",
+"private_key": "-----BEGIN PRIVATE KEY-----\nAnd_here_is_a_long_text_of_random_characters_that_defines_the_private_key\n-----END PRIVATE KEY-----\n",
+```
+
+Take these two values, put them into `LOKSE_SERVICE_ACCOUNT_EMAIL` and `LOKSE_PRIVATE_KEY` variables using one of two ways [described above](#environment-variables) and there you go, fetching data from spreadsheet should work now.
+
+## API key
+
+For read only access, we're good with usage of API key, if you don't have any, follow [the instructions here](https://theoephraim.github.io/node-google-spreadsheet/#/getting-started/authentication?id=api-key) to create one.
+
+Then define the variable `LOKSE_API_KEY=this_is_your_api_key` and then if the key is valid fetching data should work for you.
+
+Using API key instead of Service account has one important limitation: You spreadsheet must set permissions to be visible for everyone in the Internet.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,6 @@
   },
   "bugs": "https://github.com/AckeeCZ/lokse/issues",
   "dependencies": {
-    "@oclif/errors": "^1.3.4",
     "@types/bluebird": "^3.5.32",
     "@types/dedent": "^0.7.0",
     "@types/google-spreadsheet": "^3.0.1",

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -8,7 +8,7 @@ export class MissingAuthError extends CLIError {
     super(
       dedent`
           Cannot authenticate to fetch Spreadsheet data. 
-            Provide either Service account credentials or API key 🔑 See detail info at https://github.com/AckeeCZ/lokse/tree/master/packages/lokse#authentication
+            Provide either Service account credentials or API key 🔑 See detail info at https://github.com/AckeeCZ/lokse/tree/master/packages/core/doc/authentication.md
           `
     );
     this.name = "MissingAuthError";

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,7 +1,8 @@
-import { CLIError } from "@oclif/errors";
 import * as dedent from "dedent";
 
-export class MissingAuthError extends CLIError {
+export class FatalError extends Error {}
+
+export class MissingAuthError extends FatalError {
   public name: string;
 
   constructor() {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,3 +10,5 @@ export { default as FileWriter } from "./writer";
 export { default as Line } from "./line";
 
 export { OutputFormat } from "./constants";
+
+export { FatalError } from "./errors";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,8 @@ export { Reader, WorksheetReader, InvalidFilterError } from "./reader";
 
 export type { WorksheetLinesByTitle, SheetsFilter } from "./reader";
 
+export type { Logger } from "./logger";
+
 export { transformersByFormat } from "./transformer";
 
 export { default as FileWriter } from "./writer";

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,1 +1,6 @@
-export default console;
+export interface Logger {
+  log: (...args: any[]) => void;
+  warn: (...args: any[]) => void;
+}
+
+export default console as Logger;

--- a/packages/core/src/reader/__tests__/spreadsheet-reader.test.ts
+++ b/packages/core/src/reader/__tests__/spreadsheet-reader.test.ts
@@ -14,6 +14,11 @@ const GoogleSpreadsheetMock = GoogleSpreadsheet as jest.Mock;
 jest.mock("google-spreadsheet");
 
 describe("SpreadsheetReader", () => {
+  const testLogger = {
+    log: jest.fn(),
+    warn: jest.fn(),
+  };
+
   describe("authenticate", () => {
     beforeEach(() => {
       GoogleSpreadsheetMock.mockClear();
@@ -80,7 +85,6 @@ describe("SpreadsheetReader", () => {
   });
 
   describe("read", () => {
-    let consoleErrorBackup: typeof console.error;
     const makeFakeLine = (id: string) => {
       return ({ id: `line_${id}` } as unknown) as Line;
     };
@@ -103,14 +107,8 @@ describe("SpreadsheetReader", () => {
 
     const linesSet3 = [makeFakeLine("3_1")];
 
-    /* eslint-disable no-console */
     beforeEach(() => {
-      consoleErrorBackup = console.error;
-      console.error = jest.fn();
-    });
-
-    afterEach(() => {
-      console.error = consoleErrorBackup;
+      testLogger.warn.mockReset();
     });
 
     it("should return map of lines by sheet title", async () => {
@@ -124,7 +122,8 @@ describe("SpreadsheetReader", () => {
 
       const reader = new SpreadsheetReader(
         "test-sheet-id",
-        new WorksheetReader("*")
+        new WorksheetReader("*"),
+        { logger: testLogger }
       );
       jest.spyOn(reader, "fetchSheets").mockResolvedValue(sheetsList);
 
@@ -160,7 +159,8 @@ describe("SpreadsheetReader", () => {
 
       const reader = new SpreadsheetReader(
         "test-sheet-id",
-        new WorksheetReader("*")
+        new WorksheetReader("*"),
+        { logger: testLogger }
       );
       jest.spyOn(reader, "fetchSheets").mockResolvedValue(sheetsList);
 
@@ -168,12 +168,12 @@ describe("SpreadsheetReader", () => {
         fakeSheet1: linesSet1,
         fakeSheet4: linesSet3,
       });
-      expect(console.error).toHaveBeenCalledTimes(2);
-      expect(console.error).toHaveBeenNthCalledWith(
+      expect(testLogger.warn).toHaveBeenCalledTimes(2);
+      expect(testLogger.warn).toHaveBeenNthCalledWith(
         1,
         expect.stringContaining(mockLangColError.message)
       );
-      expect(console.error).toHaveBeenNthCalledWith(
+      expect(testLogger.warn).toHaveBeenNthCalledWith(
         2,
         expect.stringContaining(mockKeyColError.message)
       );
@@ -190,7 +190,8 @@ describe("SpreadsheetReader", () => {
 
       const reader = new SpreadsheetReader(
         "test-sheet-id",
-        new WorksheetReader("*")
+        new WorksheetReader("*"),
+        { logger: testLogger }
       );
       jest.spyOn(reader, "fetchSheets").mockResolvedValue(sheetsList);
 
@@ -198,8 +199,8 @@ describe("SpreadsheetReader", () => {
         fakeSheet1: linesSet1.concat(linesSet3),
         fakeSheet2: linesSet2,
       });
-      expect(console.error).toHaveBeenCalledTimes(1);
-      expect(console.error).toHaveBeenCalledWith(
+      expect(testLogger.warn).toHaveBeenCalledTimes(1);
+      expect(testLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining(
           `🔀 Found two sheets with same title fakeSheet1`
         )

--- a/packages/core/src/reader/spreadsheet-reader.ts
+++ b/packages/core/src/reader/spreadsheet-reader.ts
@@ -1,15 +1,20 @@
 import { GoogleSpreadsheet } from "google-spreadsheet";
-import { CLIError, warn } from "@oclif/errors";
+import { CLIError } from "@oclif/errors";
 
 import Line from "../line";
 import { MissingAuthError } from "../errors";
 import WorksheetReader from "./worksheet-reader";
 import Worksheet from "./worksheet";
+import defaultLogger from "../logger";
+import type { Logger } from "../logger";
 
 export declare type WorksheetLinesByTitle = {
   [worksheetTitle: string]: Line[];
 };
 
+interface SpreadsheetReaderOptions {
+  logger?: Logger;
+}
 export class SpreadsheetReader {
   private spreadsheet: GoogleSpreadsheet;
 
@@ -17,7 +22,15 @@ export class SpreadsheetReader {
 
   private worksheets: Worksheet[] | null;
 
-  constructor(spreadsheetId: string, sheetsReader: WorksheetReader) {
+  public logger: Logger;
+
+  constructor(
+    spreadsheetId: string,
+    sheetsReader: WorksheetReader,
+    options: SpreadsheetReaderOptions = {}
+  ) {
+    this.logger = options.logger || defaultLogger;
+
     this.spreadsheet = new GoogleSpreadsheet(spreadsheetId);
     this.sheetsReader = sheetsReader;
 
@@ -71,7 +84,7 @@ export class SpreadsheetReader {
           const lines = worksheet.extractLines(keyColumn, valueColumn);
 
           if (worksheetLines[title]) {
-            warn(
+            this.logger.warn(
               `🔀 Found two sheets with same title ${title}. We're gonna concat the data.`
             );
 
@@ -80,7 +93,7 @@ export class SpreadsheetReader {
             worksheetLines[title] = lines;
           }
         } catch (error) {
-          warn(error.message);
+          this.logger.warn(error.message);
         }
 
         return worksheetLines;

--- a/packages/core/src/reader/spreadsheet-reader.ts
+++ b/packages/core/src/reader/spreadsheet-reader.ts
@@ -1,8 +1,7 @@
 import { GoogleSpreadsheet } from "google-spreadsheet";
-import { CLIError } from "@oclif/errors";
 
 import Line from "../line";
-import { MissingAuthError } from "../errors";
+import { MissingAuthError, FatalError } from "../errors";
 import WorksheetReader from "./worksheet-reader";
 import Worksheet from "./worksheet";
 import defaultLogger from "../logger";
@@ -64,7 +63,7 @@ export class SpreadsheetReader {
       try {
         await this.spreadsheet.loadInfo();
       } catch (error) {
-        throw new CLIError(error.message);
+        throw new FatalError(error.message);
       }
 
       this.worksheets = await this.sheetsReader.read(this.spreadsheet);

--- a/packages/core/src/reader/worksheet-reader.ts
+++ b/packages/core/src/reader/worksheet-reader.ts
@@ -1,12 +1,13 @@
 import { all } from "bluebird";
-import { warn } from "@oclif/errors";
 import { isPlainObject } from "lodash";
-import {
+import type {
   GoogleSpreadsheet,
   GoogleSpreadsheetWorksheet,
 } from "google-spreadsheet";
 import { forceArray, isEqualCaseInsensitive } from "../utils";
 import Worksheet from "./worksheet";
+import defaultLogger from "../logger";
+import type { Logger } from "../logger";
 
 export class InvalidFilterError extends Error {
   public filterStringified: string;
@@ -38,12 +39,23 @@ export type SheetsFilter =
       exclude?: string | SheetIndexOrTitle[];
     };
 
+interface WorksheetReaderOptions {
+  logger?: Logger;
+}
+
 class WorksheetReader {
   static ALL_SHEETS_FILTER = "*";
 
   public filter: SheetFilterComplex;
 
-  constructor(filter?: SheetsFilter | null) {
+  public logger: Logger;
+
+  constructor(
+    filter?: SheetsFilter | null,
+    options: WorksheetReaderOptions = {}
+  ) {
+    this.logger = options.logger || defaultLogger;
+
     this.filter = WorksheetReader.normalizeFilter(filter);
   }
 
@@ -133,7 +145,7 @@ class WorksheetReader {
 
       message += ` that match the filter ${filterStringified}. Existing sheets are ${existingSheets}`;
 
-      warn(`${message}. `);
+      this.logger.warn(`${message}. `);
     }
 
     const sheets = await all(worksheets.map(this.loadSheet));


### PR DESCRIPTION
* Extract authentication documentation into standalone document
* Allow optionally passing logger into worksheet and spreadsheet reader
* Get rid of oclif dependency in core package

All these changes has one main purpose, get rid of any knowledge about lokse cli in `core` package and thus let it be real core, reusable in any other futher lokse ecosystem tools.