### PR TITLE
🐛 Set version supporting plugin types in plugin template

### DIFF
--- a/plugin-template/package.json
+++ b/plugin-template/package.json
@@ -8,7 +8,7 @@
   },
   "bugs": "https://github.com/AckeeCZ/lokse/issues",
   "dependencies": {
-    "@lokse/core": "^1.7.0"
+    "@lokse/core": "^2.0.1"
   },
   "devDependencies": {},
   "engines": {


### PR DESCRIPTION
Plugin template package.json used previous version which was not supporting the plugins yet. 

The generated plugins could use the types and `createPlugin`