### PR TITLE
Fix fallback plugin not finding default language column

### DIFF
--- a/packages/plugin-fallback/src/__tests__/index.test.ts
+++ b/packages/plugin-fallback/src/__tests__/index.test.ts
@@ -1,17 +1,39 @@
-import type { GoogleSpreadsheetRow } from 'google-spreadsheet';
+import type { GoogleSpreadsheetRow, GoogleSpreadsheetWorksheet } from 'google-spreadsheet';
 import { Line } from '@lokse/core';
 
 import fallbackPluginFactory from '..';
 import type { PluginOptions } from '..';
 
-export const createRow = (rowIndex: number, values: { [key: string]: any }) =>
-    ({
+export const createRow = (rowIndex: number, values: { [key: string]: any }) => {
+    const defaultRow = {
         rowIndex,
-        ...values,
         get: (key: string) => values[key],
         save: () => null,
         delete: () => null,
-    }) as unknown as GoogleSpreadsheetRow;
+    };
+    return new Proxy<GoogleSpreadsheetRow>({} as unknown as GoogleSpreadsheetRow, {
+        get(_t: GoogleSpreadsheetRow, p: string | symbol, _r: any): any {
+            const key = p as keyof GoogleSpreadsheetRow;
+            if (key in defaultRow) {
+                return defaultRow[key as keyof typeof defaultRow];
+            }
+
+            if (key === '_worksheet') {
+                return new Proxy<GoogleSpreadsheetWorksheet>({} as unknown as GoogleSpreadsheetWorksheet, {
+                    get(_t: GoogleSpreadsheetWorksheet, p: string | symbol, _r: any): any {
+                        if (p === ('headerValues' satisfies keyof GoogleSpreadsheetWorksheet)) {
+                            return Object.keys(values);
+                        }
+
+                        throw new Error(`GoogleSpreadsheetWorksheet::${key} not implemented`);
+                    },
+                });
+            }
+
+            throw new Error(`GoogleSpreadsheetRow::${key} not implemented`);
+        },
+    });
+};
 
 describe('Fallback plugin', () => {
     const logger = { warn: jest.fn(), log: jest.fn() };

--- a/packages/plugin-fallback/src/index.ts
+++ b/packages/plugin-fallback/src/index.ts
@@ -28,7 +28,8 @@ export default function (options: PluginOptions, { languages }: GeneralPluginMet
     return createPlugin({
         async readTranslation(line, meta) {
             if (line.key && !line.value) {
-                const defaultLanguageKey = Object.keys(meta.row).find(key => isDefaultLang(key)) ?? NOT_FOUND_KEY;
+                const defaultLanguageKey =
+                    meta.row._worksheet.headerValues.find(key => isDefaultLang(key)) ?? NOT_FOUND_KEY;
 
                 const fallbackLanguageValue = meta.row.get(defaultLanguageKey) ?? '';
 


### PR DESCRIPTION
Fallback plugin used `Object.keys` on the row to see all available columns, this may have worked in the past but now only finds internal properties of the row object.

Also updated tests to avoid this issue in the future, but the implementation is still not ideal - I am open to ideas