### PR TITLE
📝 Update gcloud auth command to work on Windows

### DIFF
--- a/docs/web/src/pages/en/authentication.md
+++ b/docs/web/src/pages/en/authentication.md
@@ -15,7 +15,7 @@ In order to fetch spreadsheet via `lokse update` command, you need to authentica
 2. Sign-in with Google:
 
     ```sh
-    gcloud auth application-default login --scopes=openid,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/spreadsheets,https://www.googleapis.com/auth/drive.file
+    gcloud auth application-default login --scopes="openid,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/spreadsheets,https://www.googleapis.com/auth/drive.file"
     ```
 
 3. Fetch spreadsheets:


### PR DESCRIPTION
Running the original command on a Windows machine caused an error (invalid scopes). The error was fixed by wrapping the scopes in quotes. I tried the updated command with quotes on Mac, and it works well, so this syntax should hopefully work everywhere. 

It seems to be a common issue on Windows, see: https://issuetracker.google.com/issues/185162453#comment6.